### PR TITLE
Reconnect on restart

### DIFF
--- a/src/System/Remote/Monitoring/Carbon.hs
+++ b/src/System/Remote/Monitoring/Carbon.hs
@@ -84,7 +84,7 @@ defaultCarbonOptions = CarbonOptions
 -- Carbon. If the thread flushing statistics throws an exception (for example, the
 -- network connection is lost), this exception will be thrown up to the thread
 -- that called 'forkCarbon'. For more control, see 'forkCarbonRestart'.
-forkCarbon :: CarbonOptions -> EKG.Store -> IO (ThreadId)
+forkCarbon :: CarbonOptions -> EKG.Store -> IO ThreadId
 forkCarbon opts store =
   do parent <- myThreadId
      forkCarbonRestart opts

--- a/src/System/Remote/Monitoring/Carbon.hs
+++ b/src/System/Remote/Monitoring/Carbon.hs
@@ -115,14 +115,15 @@ forkCarbonRestart opts store exceptionHandler =
        Network.getAddrInfo Nothing
                            (Just (T.unpack (host opts)))
                            (Just (show (port opts)))
-     c <-
+     addrInfo <-
        case addrInfos of
-         (addrInfo:_) ->
-           Carbon.connect (Network.addrAddress addrInfo)
+         (addrInfo:_) -> return $ Network.addrAddress addrInfo
          _ -> unsupportedAddressError
      let go =
-           do terminated <-
-                try (loop store c opts)
+           do
+              terminated <- try $ do
+                c <- Carbon.connect addrInfo
+                loop store c opts
               case terminated of
                 Left exception ->
                   exceptionHandler exception go


### PR DESCRIPTION
By moving the connection to Carbon into the `go` function we achieve two
goals:

1. connection exceptions get caught
2. the restart function retries to connect to Carbon

See also: https://github.com/ocharles/ekg-carbon/issues/3#issuecomment-119217541