### PR TITLE
Allow dependencies on vector=0.11.

### DIFF
--- a/ekg-carbon.cabal
+++ b/ekg-carbon.cabal
@@ -22,7 +22,7 @@ library
     text >= 0.10 && < 1.3,
     time >= 1.4 && < 1.6,
     unordered-containers,
-    vector >= 0.10 && < 0.11
+    vector >= 0.10 && < 0.12
 
   hs-source-dirs: src
   default-language: Haskell2010


### PR DESCRIPTION
This is needed when compiling with aeson 0.11.
