### PR TITLE
Add missing \ to `forkCarbonRestart` Haddocks

### DIFF
--- a/src/System/Remote/Monitoring/Carbon.hs
+++ b/src/System/Remote/Monitoring/Carbon.hs
@@ -100,12 +100,10 @@ forkCarbon opts store =
 -- For example, you can use 'forkCarbonRestart' to log failures and restart
 -- logging:
 --
--- @
--- 'forkCarbonRestart' opts
---                     store
---                     (\ex restart -> do hPutStrLn stderr ("ekg-carbon: " ++ show ex)
---                                        restart)
--- @
+-- > forkCarbonRestart defaultCarbonOptions
+-- >                   store
+-- >                   (\ex restart -> do hPutStrLn stderr ("ekg-carbon: " ++ show ex)
+-- >                                      restart)
 forkCarbonRestart :: CarbonOptions
                   -> EKG.Store
                   -> (SomeException -> IO () -> IO ())


### PR DESCRIPTION
* Switching to bird tracks (>) instead of the @ Haddock syntax means we don't need to escape markup used in the example code.
* The @ wasn't really necessary because it was only using Haddock markup to link to `forkCarbonRestart`, the very function it's documenting
* By using bird tracks it's easier to line up the code snippet. The existing Haddocks weren't taking Haddock markup into account when indenting so the code didn't line up.
* I also switched to `defaultCarbonOptions` from `opts`. This just makes it a little easier to copy/paste in the snippet if you aren't using custom Carbon options